### PR TITLE
First commit during the great linkpocolypse

### DIFF
--- a/config/css/main.css
+++ b/config/css/main.css
@@ -75,7 +75,8 @@ ul {margin-left: 1em; padding-left: 1em;}
 ul.thread li { list-style: circle outside none; }
 /* bold thread starter */
 /* ul.thread > li > a { font-weight: bold; } */
-ul.thread li a.nt { text-decoration: none; }
+ul.thread li a { text-decoration: none; }
+ul.thread li a:hover { text-decoration: underline; }
 ul.thread li img.nt { display: none; }
 ul.thread li.hidden { list-style: disc outside none; }
 


### PR DESCRIPTION
Easy change to test my gitflow.

- removed `.nt` so all links will be naked of underlines
- added `a:hover` rule for underlines to appear on hover

![selfie-0](http://i.imgur.com/mX1tTUX.png)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
