### PR TITLE
Restore NT image

### DIFF
--- a/config/css/main.css
+++ b/config/css/main.css
@@ -77,7 +77,7 @@ ul.thread li { list-style: circle outside none; }
 /* ul.thread > li > a { font-weight: bold; } */
 ul.thread li a { text-decoration: none; }
 ul.thread li a:hover { text-decoration: underline; }
-ul.thread li img.nt { display: none; }
+/* ul.thread li img.nt { display: none; } */
 ul.thread li.hidden { list-style: disc outside none; }
 
 /* subject thread listing spacing */


### PR DESCRIPTION
With the removal of all underlines, commented out the rule for hiding the NT image to restore an indication of a thread having no text.