### PR TITLE
image file uploading through imgur

### DIFF
--- a/config/setup.inc
+++ b/config/setup.inc
@@ -67,6 +67,10 @@ $default_page = "/directory.phtml";
 /* ONLY uncomment this if you know what you are doing. */
 //date_default_timezone_set(@date_default_timezone_get());
 
+/* imgur client id and secret, to allow image uploading */
+$imgur_client_id = "";
+$imgur_client_secret = "";
+
 /* allow user to override default in a separate file (prevents merge problems
    when using source control */
 if (is_file(dirname(__FILE__) . "/setup-local.inc") )

--- a/templates/post.tpl
+++ b/templates/post.tpl
@@ -46,6 +46,9 @@ what kinds of video are supported.</i></p>
 <!-- BEGIN subject_too_long -->
 <p>Subject line too long! Truncated to 100 characters</p>
 <!-- END subject_too_long -->
+<!-- BEGIN image_upload_failed -->
+<p>Image upload failed, try reducing file size</p>
+<!-- END image_upload_failed -->
 </div>
 <!-- END error -->
 <!-- BEGIN preview -->

--- a/templates/postform.tpl
+++ b/templates/postform.tpl
@@ -19,7 +19,7 @@ This thread is locked. No replies are allowed.<br>
 </p>
 <!-- END noacct -->
 <!-- BEGIN acct -->
-<form class="postform" action="/{FORUM_SHORTNAME}/{ACTION}.phtml" method="post">
+<form class="postform" action="/{FORUM_SHORTNAME}/{ACTION}.phtml" method="post" enctype="multipart/form-data">
 <table>
 <tr>
   <th>Logged in as:</th>
@@ -50,6 +50,12 @@ This thread is locked. No replies are allowed.<br>
   <th>Image URL:</th>
   <td><input class="text" type="text" name="imageurl" value="{IMAGEURL}" size="80"></td>
 </tr>
+<!-- BEGIN imageupload -->
+<tr class="input">
+  <th>Image Upload:</th>
+  <td><input class="text" type="file" name="imagefile"></td>
+</tr>
+<!-- END imageupload -->
 <tr class="input">
   <th>Video URL:</th>
   <td><input class="text" type="text" name="video" value="{VIDEO}" size="80" maxlength="250"></td>

--- a/user/message.inc
+++ b/user/message.inc
@@ -410,5 +410,42 @@ function is_msg_bumped($msg)
 */
     return ($tthread && $msg['unixtime'] > $tthread['unixtime']);
 }
+
+function can_upload_images() {
+    global $imgur_client_id, $imgur_client_secret;
+
+    return !(empty($imgur_client_id) || empty($imgur_client_secret));
+}
+
+function get_uploaded_image_url($filename) {
+    global $imgur_client_id;
+
+    if (!can_upload_images())
+      return null;
+
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, "https://api.imgur.com/3/image");
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+      "Authorization: Client-ID " . $imgur_client_id,
+    ));
+    curl_setopt($ch, CURLOPT_POSTFIELDS, array(
+      "image" => file_get_contents($filename),
+    ));
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $result = curl_exec($ch);
+
+    if ($result != "") {
+      $j = json_decode($result, true);
+      if ($j["data"] && $j["data"]["link"])
+        return $j["data"]["link"];
+      else
+        error_log("error from imgur: " . var_export($j, true));
+    } else
+      error_log("null response from imgur");
+
+    return null;
+}
+
 // vim:sw=2
 ?>

--- a/user/post.php
+++ b/user/post.php
@@ -37,6 +37,7 @@ $tpl->set_block("error", "video");
 $tpl->set_block("error", "subject_req");
 $tpl->set_block("error", "subject_change");
 $tpl->set_block("error", "subject_too_long");
+$tpl->set_block("error", "image_upload_failed");
 $tpl->set_block("post", "preview");
 $tpl->set_block("post", "duplicate");
 $tpl->set_block("post", "form");
@@ -49,6 +50,7 @@ $errors = array(
   "image",
   "video",
   "subject_req",
+  "image_upload_failed",
   "subject_change",
   "subject_too_long",
 );
@@ -174,11 +176,22 @@ if (isset($_POST['postcookie'])) {
     $msg['subject'] = substr($msg['subject'], 0, 100);
   }
 
-  /* first time around, there is an imageurl set, and the user
-   did not preview, force the action to "preview" */
-  if ((!empty($msg['imageurl']) || !empty($msg['video']))
-    && !isset($imgpreview)) {
-    $preview = 1;
+  /* if uploading an image, proxy it to the image host and replace our image url */
+  if (!isset($error) && can_upload_images() && isset($_FILES["imagefile"]) &&
+  $_FILES["imagefile"]["size"] > 0) {
+    $newimageurl = get_uploaded_image_url($_FILES["imagefile"]["tmp_name"]);
+
+    if ($newimageurl) {
+      $msg["imageurl"] = $newimageurl;
+    } else {
+      $error["image_upload_failed"] = true;
+    }
+  } else {
+    /* first time around, there is an imageurl set, and the user
+     did not preview, force the action to "preview" */
+    if ((!empty($msg['imageurl']) || !empty($msg['video'])) && !isset($imgpreview)) {
+      $preview = 1;
+    }
   }
 
   if ((isset($error) || isset($preview))) {

--- a/user/postform.inc
+++ b/user/postform.inc
@@ -47,24 +47,28 @@ function render_postform($tpl, $action, $user, $msg=null, $imgpreview=false)
     $tpl->set_block("enabled", "noacct");
 
     $tpl->set_block("acct", "offtopic");
+    $tpl->set_block("acct", "imageupload");
 
     if (isset($thread) && !isset($forum['option']['PostReply']) && !$user->capable($forum['fid'], 'Delete')) {
       $tpl->set_var(array(
 	"enabled" => "",
 	"locked" => "",
 	"nonewthreads" => "",
+	"imageupload" => "",
       ));
     } else if (!isset($thread) && !isset($forum['option']['PostThread']) && !$user->capable($forum['fid'], 'Delete')) {
       $tpl->set_var(array(
 	"enabled" => "",
 	"locked" => "",
 	"noreplies" => "",
+	"imageupload" => "",
       ));
     } else if (isset($thread) && isset($thread['flag']['Locked']) && !$user->capable($forum['fid'], 'Lock')) {
       $tpl->set_var(array(
 	"enabled" => "",
 	"nonewthreads" => "",
 	"noreplies" => "",
+	"imageupload" => "",
       ));
     } else if (isset($user->aid)) {
 
@@ -119,6 +123,9 @@ function render_postform($tpl, $action, $user, $msg=null, $imgpreview=false)
 
       $tpl->set_var("USER_NAME", $user->name);
       $tpl->set_var("USER_EMAIL", $user->email);
+
+      if (!can_upload_images() || isset($msg["mid"]))
+	$tpl->set_var("imageupload", "");
 
       /***************/
       /* check boxes */


### PR DESCRIPTION
I noticed the thread at https://forums.wayot.org/other/msgs/8427761.phtml and whipped this up.

Register an API key at https://api.imgur.com/oauth2/addclient (for anonymous usage)

Set `$imgur_client_id` and `$imgur_client_secret` in `config{-local,}.inc`, and then an "Image Upload" line will appear on the new message form. 

When PHP processes the file upload, pass it to imgur's API and get back a direct image URL, which then overwrites the user's image URL entered on the form (if any).

Everything going forward (previewing, viewing, editing) just operates on the image URL field as if the user put it there.