### PR TITLE
log imgur delete url, and force image urls to https

### DIFF
--- a/user/message.inc
+++ b/user/message.inc
@@ -417,7 +417,7 @@ function can_upload_images() {
     return !(empty($imgur_client_id) || empty($imgur_client_secret));
 }
 
-function get_uploaded_image_url($filename) {
+function get_uploaded_image_urls($filename) {
     global $imgur_client_id;
 
     if (!can_upload_images())
@@ -438,9 +438,8 @@ function get_uploaded_image_url($filename) {
     if ($result != "") {
       $j = json_decode($result, true);
       if ($j["data"] && $j["data"]["link"]) {
-      	$iu = preg_replace("/^http:/", "https:", $j["data"]["link"]);
-        error_log($iu . " delete url: https://imgur.com/delete/" . $j["data"]["deletehash"]);
-        return $iu;
+        $iu = preg_replace("/^http:/", "https:", $j["data"]["link"]);
+        return array($iu, "https://imgur.com/delete/" . $j["data"]["deletehash"]);
       } else {
         error_log("error from imgur: " . var_export($j, true));
       }

--- a/user/message.inc
+++ b/user/message.inc
@@ -437,10 +437,13 @@ function get_uploaded_image_url($filename) {
 
     if ($result != "") {
       $j = json_decode($result, true);
-      if ($j["data"] && $j["data"]["link"])
-        return $j["data"]["link"];
-      else
+      if ($j["data"] && $j["data"]["link"]) {
+      	$iu = preg_replace("/^http:/", "https:", $j["data"]["link"]);
+        error_log($iu . " delete url: https://imgur.com/delete/" . $j["data"]["deletehash"]);
+        return $iu;
+      } else {
         error_log("error from imgur: " . var_export($j, true));
+      }
     } else
       error_log("null response from imgur");
 

--- a/user/post.php
+++ b/user/post.php
@@ -179,10 +179,11 @@ if (isset($_POST['postcookie'])) {
   /* if uploading an image, proxy it to the image host and replace our image url */
   if (!isset($error) && can_upload_images() && isset($_FILES["imagefile"]) &&
   $_FILES["imagefile"]["size"] > 0) {
-    $newimageurl = get_uploaded_image_url($_FILES["imagefile"]["tmp_name"]);
+    $newimageurls = get_uploaded_image_urls($_FILES["imagefile"]["tmp_name"]);
 
-    if ($newimageurl) {
-      $msg["imageurl"] = $newimageurl;
+    if ($newimageurls) {
+      $msg["imageurl"] = $newimageurls[0];
+      $msg["imagedeleteurl"] = $newimageurls[1];
     } else {
       $error["image_upload_failed"] = true;
     }

--- a/user/postmessage.inc
+++ b/user/postmessage.inc
@@ -117,13 +117,19 @@ function postmessage($user, $fid, &$msg, $request)
     /* FIXME: translate pid -> pmid */
     $sql = "insert into $mtable " .
 	"( mid, aid, pid, tid, name, email, date, ip, flags, subject, message, url, urltext, video, state, views, changes ) "
-            . "values ( ?, ?, ?, ?, ?, ?, NOW(), ?, ?, ?, ?, ?, ?, ?, ?, 0, '' );";
+            . "values ( ?, ?, ?, ?, ?, ?, NOW(), ?, ?, ?, ?, ?, ?, ?, ?, 0, ? );";
+
+    if ($msg["imagedeleteurl"]) {
+      $msg["changes"] = "image delete url for " . $msg["imageurl"] . " = " . $msg["imagedeleteurl"];
+    } else {
+      $msg["changes"] = "";
+    }
 
     db_exec($sql, array(
       $msg['mid'], $user->aid, $msg['pmid'] ? $msg['pmid'] : 0, $msg['tid'] ? $msg['tid'] : 0, $msg['name'],
       $msg['email'], $msg['ip'], $msg['flags'], $msg['subject'],
       $msg['message'], $msg['url'], $msg['urltext'], $msg['video'],
-      $msg['state']
+      $msg['state'], $msg['changes']
     ));
 
     if (!$msg['pmid']) {


### PR DESCRIPTION
in case a user uploads an image they want to take down, just
removing it from the image url field won't remove it from the
interwebs.  logging the delete url will at least let an admin find
it and give it to the user.

ideally, the imgur url and its delete url would actually get put
into their own fields in f_messages*, so when the user edits the
post and deletes it, an api call can be made to delete it from imgur
as well (or at least show the delete url to the user).  but this
requires database migrations and some heavy code changes since
images are just converted to html in the message field.

also change image urls to https because imgur supports it and
privacy is good.