### PR TITLE
Sticky Message Lookup optimization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you are migrating from an older version of kawf, please read
 ## docker build
 You need to build kawf first before you can run docker-compose (or just docker run). The build uses environment variables, first create that file (not in the repository):
 ```
-cp config/sample-envfile config/envfile
+cp config/sample-envvars config/envvars
 ```
 Edit to taste.
 

--- a/admin/forumadd.php
+++ b/admin/forumadd.php
@@ -39,6 +39,8 @@ if (isset($_POST['submit'])) {
 
   db_exec(sprintf($create_message_table, $iid));
   db_exec(sprintf($create_thread_table, $iid));
+  db_exec(sprintf($create_sticky_table, $iid));
+  db_exec(sprintf($create_sticky_trigger, $iid, $iid, $iid, $iid));
 
   Header("Location: index.phtml?message=" . urlencode("Forum Added"));
   exit;

--- a/db/migrations/20220625100000_add_sticky_tables.php
+++ b/db/migrations/20220625100000_add_sticky_tables.php
@@ -26,6 +26,12 @@ class AddStickyTables extends DatabaseMigration {
     "end ";
 	echo "Creating update trigger for $tbl\n";
   db_exec($sqlTrigger);
+  $sqlUpdateStickyTable = "insert into " . $tbl . " (tid, mid) " .
+    "select tid, mid " .
+    "from " . $triggertbl . " " .
+    "where flags like '%STICKY%';";
+  echo "Backfilling $tbl with stuck threads\n";
+  db_exec($sqlUpdateStickyTable);
     }
     $sth->closeCursor();
   }

--- a/db/migrations/20220625100000_add_sticky_tables.php
+++ b/db/migrations/20220625100000_add_sticky_tables.php
@@ -7,7 +7,7 @@ class AddStickyTables extends DatabaseMigration {
     while ($i = $sth->fetch() ) {
   $tbl = "f_sticky" . $i['iid'];
   $triggertbl = "f_threads" . $i['iid'];
-	$sqlTable = "create table if not exists f_sticky". $tbl . " (" . 
+	$sqlTable = "create table if not exists ". $tbl . " (" . 
     "sid int NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Primary Key', " .
     "tid int not null, " .
     "mid int not null " .
@@ -19,9 +19,9 @@ class AddStickyTables extends DatabaseMigration {
     "for each row " . 
     "begin " .
     "  if new.flags like '%STICKY%' then " .
-    "    insert into f_sticky" . $tbl . "(tid, mid) values (new.tid, new.mid); " .
+    "    insert into " . $tbl . "(tid, mid) values (new.tid, new.mid); " .
     " else " .
-    "    delete from f_sticky" . $tbl. " where tid = new.tid; " .     
+    "    delete from " . $tbl . " where tid = new.tid; " .     
     "end if; " .
     "end ";
 	echo "Creating update trigger for $tbl\n";

--- a/db/migrations/20220625100000_add_sticky_tables.php
+++ b/db/migrations/20220625100000_add_sticky_tables.php
@@ -1,0 +1,34 @@
+<?php
+
+class AddStickyTables extends DatabaseMigration {
+  public function migrate() {
+    $sth = db_query("select iid from f_indexes order by iid");
+    echo "DO NOT INTERRUPT, this could take quite some time!\n";
+    while ($i = $sth->fetch() ) {
+  $tbl = "f_sticky" . $i['iid'];
+  $triggertbl = "f_threads" . $i['iid'];
+	$sqlTable = "create table if not exists f_sticky". $tbl . " (" . 
+    "sid int NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Primary Key', " .
+    "tid int not null, " .
+    "mid int not null " .
+    ")";
+	echo "Creating $tbl\n";
+	db_exec($sqlTable);
+  $sqlTrigger = "create trigger trigger_" . $tbl . "_sticky_update " .
+    "after update on " . $triggertbl . " " .
+    "for each row " . 
+    "begin " .
+    "  if new.flags like '%STICKY%' then " .
+    "    insert into f_sticky" . $tbl . "(tid, mid) values (new.tid, new.mid); " .
+    " else " .
+    "    delete from f_sticky" . $tbl. " where tid = new.tid; " .     
+    "end if; " .
+    "end ";
+	echo "Creating update trigger for $tbl\n";
+  db_exec($sqlTrigger);
+    }
+    $sth->closeCursor();
+  }
+}
+
+?>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
    db:
-     image: mysql:5.7
+     image: mariadb:10.5.8
      volumes:
        - 'db_data:/var/lib/mysql'
      restart: unless-stopped

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-apache
 
 # add dependencies
 RUN apt-get update && apt-get install -y \
-      mariadb-client-10.1 \
+      mariadb-client-10.3 \
       tar \
       unzip \
       vim \

--- a/tools/createforum.php
+++ b/tools/createforum.php
@@ -35,5 +35,7 @@ db_exec("insert into f_unique ( fid, type, id ) values ( ?, 'Thread', 0 )", arra
 
 db_exec(sprintf($create_message_table, $iid));
 db_exec(sprintf($create_thread_table, $iid));
+db_exec(sprintf($create_sticky_table, $iid));
+db_exec(sprintf($create_sticky_trigger, $iid, $iid, $iid, $iid));
 
 ?>

--- a/user/showforum.php
+++ b/user/showforum.php
@@ -157,7 +157,7 @@ if ($curpage == 1) {
   /* show stickies next */
   /**********************/
   foreach ($indexes as $index) {
-    $sql = "select *, UNIX_TIMESTAMP(tstamp) as unixtime from f_threads" . $index['iid'] . " where flags like '%Sticky%'";
+    $sql = "select *, UNIX_TIMESTAMP(tstamp) as unixtime from f_threads" . $index['iid'] . " where tid in (SELECT tid FROM f_sticky" . $index['iid'] . ")";
     $sth = db_query($sql);
     while ($thread = $sth->fetch()) {
 	gen_thread_flags($thread);

--- a/user/showforum.php
+++ b/user/showforum.php
@@ -157,7 +157,7 @@ if ($curpage == 1) {
   /* show stickies next */
   /**********************/
   foreach ($indexes as $index) {
-    $sql = "select *, UNIX_TIMESTAMP(tstamp) as unixtime from f_threads" . $index['iid'] . " where tid in (SELECT tid FROM f_sticky" . $index['iid'] . ")";
+    $sql = "select *, UNIX_TIMESTAMP(tstamp) as unixtime from f_threads" . $index['iid'] . " where mid in (SELECT mid FROM f_sticky" . $index['iid'] . ")";
     $sth = db_query($sql);
     while ($thread = $sth->fetch()) {
 	gen_thread_flags($thread);

--- a/user/tables.inc
+++ b/user/tables.inc
@@ -4,7 +4,7 @@
 # TODO: automatically derive this from db/migrations contents.
 $SCHEMA_VERSION = "20180713130236";
 
-# f_messages* and f_threads* are create automatically when you create a form
+# f_messages*, f_threads*, f_sticky*, and associated trigger are create automatically when you create a form
 #    pmid int not null,
 $create_message_table = "
   create table if not exists f_messages%d (
@@ -43,6 +43,29 @@ $create_thread_table = "
     primary key (tid),
     index (mid)
   )";
+
+$create_sticky_trigger = "
+  create trigger trigger_f%d_sticky_update
+  after update on f_threads%d
+  for each row
+  begin
+    if new.flags like '%%STICKY%%' then 
+      insert into f_sticky%d(tid, mid) values (new.tid, new.mid);
+    else 
+      delete from f_sticky%d where tid = new.tid;     
+  end if; 
+  end
+  ";
+
+
+$create_sticky_table = "
+  create table if not exists f_sticky%d (
+    sid int NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Primary Key',
+    tid int not null,
+    mid int not null
+  )";
+
+
 
 # Unused
 $create_visits_table = "

--- a/user/tables.inc
+++ b/user/tables.inc
@@ -2,7 +2,7 @@
 
 # Update this to the proper migration when changing the schema.
 # TODO: automatically derive this from db/migrations contents.
-$SCHEMA_VERSION = "20180713130236";
+$SCHEMA_VERSION = "20220625100000";
 
 # f_messages*, f_threads*, f_sticky*, and associated trigger are create automatically when you create a form
 #    pmid int not null,


### PR DESCRIPTION
This updates docker files to allow for build to complete due to client updates. Docker compose was updated to allow for x86/x64/armv8 platforms. 
This creates new f_sicky* tables for each forum that will update when the f_threads*. The view form lookup to order sticky threads uses indexed column 'mid' and a requires a less complicated execution plan to speed up performance at the cost of slightly slower updates to existing thread flags. 