### PR TITLE
Fix for thread order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 BUILD_TYPE?=kawf
 
-.PHONY: all docker-build docker-init
+.PHONY: all docker-build docker-init docker-update
 all:
-	@echo "usage: 'make docker-build' or 'make docker-init'"
+	@echo "usage: 'make docker-build,' 'make docker-init,' or 'make docker-re-up'"
 
 docker-build:
 	BUILD_TYPE=${BUILD_TYPE} docker-compose -f docker-compose.yaml -f docker/docker-compose-tasks.yaml build
@@ -12,3 +12,8 @@ docker-init:
 
 docker-up:
 	docker-compose up -d && docker-compose logs -f
+
+docker-update: docker-down docker-build docker-up
+
+docker-down:
+	docker-compose down


### PR DESCRIPTION
This fixes #54 by forcing order on the sticky thread select.