### PR TITLE
Automatically generate schema version

### DIFF
--- a/db/include/migration.inc
+++ b/db/include/migration.inc
@@ -50,6 +50,27 @@ class DatabaseMigration {
     return $matching;
   }
 
+  public static function get_latest_schema_version($dirpath) {
+    // Given the path to the directory containing the migrations,
+    // will return latest database SCHEMA_VERSION based list of filepaths.
+    if(! is_dir($dirpath)) {
+      return array();
+    }
+    $all = glob($dirpath . "/*.php"); 
+    $latest = '';
+    foreach($all as $filepath) {
+      $parts = explode("_", basename($filepath, ".php"), 2);
+      $version = $parts[0];
+      if(! preg_match('/^\d+$/', $version)) {
+        continue;
+      }      
+      if($version > $latest) {
+        $latest = $version;
+      }
+    }
+    return $latest;
+  }
+
   public static function find_current_version() {
     // Find the current schema version in the database.
     // db_connect() should have been called before this.

--- a/db/migrations/20220723155456_extend_schema_version.php
+++ b/db/migrations/20220723155456_extend_schema_version.php
@@ -1,0 +1,16 @@
+<?php
+
+class ExtendSchemaVersion extends DatabaseMigration {
+  public function migrate() {
+    $sql = "SELECT @count :=  count(*)-1 FROM kawf.schema_version; " .
+            "PREPARE STMT FROM 'delete FROM schema_version limit ?'; " .
+            "EXECUTE STMT USING @count;";
+    db_exec($sql);
+
+    $sql = "ALTER TABLE schema_version " .
+           "ADD integrity_keeper ENUM('') NOT NULL PRIMARY KEY;";
+    db_exec($sql);
+  }
+}
+
+?>

--- a/tools/initial.php
+++ b/tools/initial.php
@@ -4,6 +4,11 @@ $kawf_base = realpath(dirname(__FILE__) . "/..");
 require_once($kawf_base . "/config/config.inc");
 require_once($kawf_base . "/include/sql.inc");
 require_once($kawf_base . "/user/tables.inc");
+require_once($kawf_base . "/db/include/migration.inc");
+
+$migrationsdirpath = $kawf_base . "/db/migrations";
+$databaseMigration = new DatabaseMigration();
+$current_schema_version = $databaseMigration->get_latest_schema_version($migrationsdirpath);
 
 if(!ini_get('safe_mode'))
     set_time_limit(0);
@@ -27,7 +32,7 @@ db_exec($create_user_preferences_table);
 db_exec($create_global_messages_table);
 
 db_exec($create_schema_version_table);
-db_exec($set_current_schema_version);
+db_exec($set_current_schema_version, array($current_schema_version));
 
 /* Static preferences. */
 db_exec($insert_static_preferences);

--- a/user/tables.inc
+++ b/user/tables.inc
@@ -53,15 +53,12 @@ $create_sticky_trigger = "
   end
   ";
 
-
 $create_sticky_table = "
   create table if not exists f_sticky%d (
     sid int NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Primary Key',
     tid int not null,
     mid int not null
   )";
-
-
 
 # Unused
 $create_visits_table = "
@@ -253,6 +250,7 @@ $create_user_preferences_table = "
 # schema version.
 $create_schema_version_table = "
   create table if not exists schema_version (
+    integrity_keeper ENUM('') NOT NULL PRIMARY KEY,
     version varchar(14) not null
   )";
 
@@ -261,6 +259,8 @@ $set_current_schema_version = "
     (version)
   values
     (?)
+  on duplicate key update
+    version = version 
   ";
 
 # ACL - IP bans.

--- a/user/tables.inc
+++ b/user/tables.inc
@@ -1,9 +1,5 @@
 <?php
 
-# Update this to the proper migration when changing the schema.
-# TODO: automatically derive this from db/migrations contents.
-$SCHEMA_VERSION = "20220625100000";
-
 # f_messages*, f_threads*, f_sticky*, and associated trigger are create automatically when you create a form
 #    pmid int not null,
 $create_message_table = "
@@ -264,7 +260,7 @@ $set_current_schema_version = "
   insert into schema_version
     (version)
   values
-    ('$SCHEMA_VERSION')
+    (?)
   ";
 
 # ACL - IP bans.


### PR DESCRIPTION
This addresses issue #47, schema version is automatically generated when db is initialized. Add primary key to schema_version to enforce a single row entry. Migration removes all but 1 schema_version row prior to altering table schema.  