### PR TITLE
Add static resource cache directives

### DIFF
--- a/config/index.php
+++ b/config/index.php
@@ -27,15 +27,19 @@ function readfile_header($file)
     //header('Content-Description: File Transfer');
     //header('Content-Disposition: attachment; filename="'.basename($file).'"');
 
-    /* TODO: compare against $_SERVER['HTTP_IF_NONE_MATCH'] */
-    //$etag = md5_file($file);
-    //header('Etag: '.$etag);
+    $last_modified_time = filemtime($file); 
+    $etag = md5_file($file); 
 
-    /* TODO: compare against $_SERVER['HTTP_IF_MODIFIED_SINCE'] */
-    //$mtime = filemtime($file);
-    //header('Last-Modified: '.gmdate('D, d M Y H:i:s', $mtime).' GMT');
-
+    if (@strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) == $last_modified_time || 
+        trim($_SERVER['HTTP_IF_NONE_MATCH']) == $etag) { 
+        header("HTTP/1.1 304 Not Modified"); 
+        return;
+    }
+    
     header('Content-Length: ' . filesize($file));
+    header("Last-Modified: " . gmdate("D, d M Y H:i:s", $last_modified_time)." GMT"); 
+    header("Etag: $etag"); 
+    header('cache-control: public, max-age=86400, no-cache');
     readfile($file);
 }
 


### PR DESCRIPTION
Completes old TODO/issue #66. Uses HTTP_IF_MODIFIED_SINCE and HTTP_IF_NONE_MATCH request headers to provide conditional caching for static resources. Net performance improvement to page load time is minimal however data transfers are reduced dramatically. Server load to return a 304 status is similar to reading, transferring resource, and returning 200 status. 