### PR TITLE
Update docker configuration for migration to PHP8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BUILD_TYPE?=kawf
 
 .PHONY: all docker-build docker-init docker-update
 all:
-	@echo "usage: 'make docker-build,' 'make docker-init,' or 'make docker-re-up'"
+	@echo "usage: 'make docker-build,' 'make docker-init,' or 'make docker-update'"
 
 docker-build:
 	BUILD_TYPE=${BUILD_TYPE} docker-compose -f docker-compose.yaml -f docker/docker-compose-tasks.yaml build

--- a/config/sample-envvars
+++ b/config/sample-envvars
@@ -11,3 +11,4 @@ MYSQL_PASSWORD=password
 BOUNCE_HOST=bounce.kawf.org
 COOKIE_HOST=.kawf.org
 DOMAIN=kawf.org
+P2F_ADDRESS=""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
-FROM php:7.2-apache
+FROM php:8.1-apache
 
 # add dependencies
 RUN apt-get update && apt-get install -y \
-      mariadb-client-10.3 \
+      mariadb-client-10.5 \
       tar \
       unzip \
       vim \
-    && /usr/local/bin/docker-php-ext-install -j$(nproc) mysqli pdo_mysql shmop
+    && /usr/local/bin/docker-php-ext-install -j$(nproc) mysqli pdo_mysql opcache
 
 # use custom php configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/docker/config-local.inc
+++ b/docker/config-local.inc
@@ -6,4 +6,5 @@ $sql_ro_username = getenv('RO_USERNAME');
 $sql_ro_password = getenv('RO_PASSWORD');
 $bounce_host = getenv('BOUNCE_HOST');
 $cookie_host = getenv('COOKIE_HOST');
+$p2f_address = array(getenv('P2F_ADDRESS'));
 ?>


### PR DESCRIPTION
Updated docker configuration to allow for running with only updating envars.  
P2F variable initialization from enviers
Migrated to PHP8.1, added opcache, removed unused shmop
Makefile correction to eliminate typo. 

