### PR TITLE
Account for no p2f vars in config.

### DIFF
--- a/user/message.inc
+++ b/user/message.inc
@@ -123,10 +123,13 @@ function _message_render_extras($tpl, $msg, $viewer, $owner)
       }
     }
   }
-  if (array_key_exists($forum['shortname'], $p2f_address) && $p2f_address[$forum['shortname']]) {
-    $tpl->set_var('P2F', $p2f_address[$forum['shortname']]);
-  } else {
-    $tpl->set_var('p2freply', "");
+  
+  if (isset($p2f_address)) {
+    if (array_key_exists($forum['shortname'], $p2f_address) && $p2f_address[$forum['shortname']]) {
+      $tpl->set_var('P2F', $p2f_address[$forum['shortname']]);
+    } else {
+      $tpl->set_var('p2freply', "");
+    }
   }
 
   blank_extra($tpl, "owner", $own);


### PR DESCRIPTION
If there aren't any p2f variables in the config then messages won't load at all. This is a basic check for the config var being set. 