### PR TITLE
Fix trigger for f_sticky

### DIFF
--- a/db/migrations/20221114170158_revise_sticky_triggers.php
+++ b/db/migrations/20221114170158_revise_sticky_triggers.php
@@ -1,0 +1,48 @@
+<?php
+
+class ReviseStickyTriggers extends DatabaseMigration {
+  public function migrate() {
+    $sth = db_query("select iid from f_indexes order by iid");
+    $forumindexids = $sth->fetchAll();
+    $sth->closeCursor();
+    echo "DO NOT INTERRUPT, this update should complete shortly\n";
+    foreach($forumindexids as $forumindexid) {
+      $triggertbl = "f_threads" . $forumindexid['iid'];
+      $stickytbl = "f_sticky" . $forumindexid['iid'];
+      $tiggername = "trigger_f" . $forumindexid['iid'];
+
+      echo "Updating $tiggername for $triggertbl / $stickytbl\n";
+      $sqlTriggerCreation = 
+        "drop trigger if exists trigger_" . $stickytbl . "_sticky_update; " . //cleans up old trigger created by migration
+        "drop trigger if exists " . $tiggername . "_sticky_update; " . //cleans up old trigger created by new forum
+        "create trigger " . $tiggername . "_sticky_update " .
+        "after update on " . $triggertbl . " " .
+        "for each row " .
+        "begin " .
+        "if new.flags like '%STICKY%' then " .
+        "if new.flags <> old.flags then " .
+        "insert into " . $stickytbl . "(tid) values (new.tid) " .
+        "on duplicate key update tid=tid; " .
+        "end if; " .
+        "else " .
+        "delete from " . $stickytbl . " where tid = new.tid; " .
+        "end if; " .
+        "end ";
+      db_exec($sqlTriggerCreation);
+
+      echo "Updating schema on sticky table $stickytbl\n";
+      $sqlAlterStickyTable = "ALTER TABLE " .$stickytbl . " " .
+        "DROP COLUMN mid," .
+        "ADD CONSTRAINT tid_UNIQUE UNIQUE (tid);";
+      db_exec($sqlAlterStickyTable);
+
+      echo "Cleaning douplicates from sticky table $stickytbl\n";
+      $sqlCleanStickyTable = "DELETE t1 FROM . " .$stickytbl . " t1 " .
+        "INNER JOIN " .$stickytbl . " t2 " .
+        "WHERE t1.sid < t2.sid AND t1.tid = t2.tid;";
+      db_exec($sqlCleanStickyTable);
+    }
+  }
+}
+
+?>

--- a/user/showforum.php
+++ b/user/showforum.php
@@ -227,7 +227,7 @@ $threadtable = count($indexes) - 1;
     correct offset for thread selection to avoid skipping threads*/
 if ($curpage > 1) {
   foreach ($indexes as $index) {
-    $sql = "select count(distinct mid) FROM f_sticky" . $index['iid'];
+    $sql = "select count(distinct tid) FROM f_sticky" . $index['iid'];
     $row = db_query_first($sql, array());
     $stickythreads = $row[0];
   }
@@ -282,11 +282,12 @@ while ($numshown < $threadsperpage) {
     $sql .= ") order by $ttable.tid desc";
 
     /*  Limit to the maximum number of threads per page
-        correct offsets for sticky thread shown on first page */
+        correct offsets for sticky thread shown on first page 
+        all sticky threads will be shown on the first page*/
     if ($curpage == 1) {
-      $sql .= " limit " . (int)($skipthreads) . "," . (int)($threadsperpage - $numshown - $stickythreads);
+      $sql .= " limit " . (int)($skipthreads) . "," . max((int)($threadsperpage - $numshown - $stickythreads),0);
     } else {
-      $sql .= " limit " . (int)($skipthreads - $stickythreads) . "," . (int)($threadsperpage - $numshown);
+      $sql .= " limit " . max((int)($skipthreads - $stickythreads), 0) . "," . (int)($threadsperpage - $numshown);
     }
 
     $sth = db_query($sql, $sql_args);
@@ -345,7 +346,7 @@ if (!process_tthreads(true /* just count */))
 if (!$tthreadsshown)
   $tpl->set_var("update_all", "");
 
-if (!$numshown)
+if (!$numshown && !$stickythreads && !($stickythreads > $displayedthreads))
   $tpl->set_var($table_block, "<span style=\"font-size: larger;\">No messages in this forum</span><br>");
 
 /*

--- a/user/tables.inc
+++ b/user/tables.inc
@@ -46,7 +46,10 @@ $create_sticky_trigger = "
   for each row
   begin
     if new.flags like '%%STICKY%%' then
-      insert into f_sticky%d(tid, mid) values (new.tid, new.mid);
+      if new.flags <> old.flags then
+        insert into f_sticky%d(tid) values (new.tid)
+        on duplicate key update tid=tid;
+      end if;
     else
       delete from f_sticky%d where tid = new.tid;
   end if;
@@ -57,7 +60,7 @@ $create_sticky_table = "
   create table if not exists f_sticky%d (
     sid int NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Primary Key',
     tid int not null,
-    mid int not null
+    unique (tid)
   )";
 
 # Unused


### PR DESCRIPTION
Bug fix to eliminate adding duplicate entries into f_sticky on replies.
While fixing I noticed a naming convention gap between the db schema migration and the new forum creation method. This cleans up both potential naming schemes and creates a new trigger that doesn't add duplicate records into f_sticky. 